### PR TITLE
Enable Bash tool in Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_tools: "Bash"
           timeout_minutes: "60"
           # Optional: Restrict network access to specific domains only
           # experimental_allowed_domains: |


### PR DESCRIPTION
Add allowed_tools configuration to enable Bash command execution in the Claude Code action.

🤖 Generated with [Claude Code](https://claude.ai/code)